### PR TITLE
Fix for `ဦ` break

### DIFF
--- a/python/sylbreak.py
+++ b/python/sylbreak.py
@@ -46,7 +46,7 @@ else:
    
 myConsonant = ur"က-အ"
 enChar = ur"a-zA-Z0-9"
-otherChar = ur"ဣဤဥဥဧဩဪဿ၌၍၏၀-၉၊။!-/:-@[-`{-~\s"
+otherChar = ur"ဣဤဥဦဧဩဪဿ၌၍၏၀-၉၊။!-/:-@[-`{-~\s"
 ssSymbol = ur'္'
 ngaThat = ur'င်'
 aThat = ur'်'


### PR DESCRIPTION
`otherChar` ထဲမှာ `ဥ` နှစ်လုံး 😁 မှားပြီးပါသွားတာလို့ထင်ပါတယ်။

စမ်းကြည့်တဲ့အခါမှာ `ဝန်ကြီးချုပ်ဦးဖြိုးမင်းသိန်း` ဆိုရင် `ဝန်| ကြီး| ချုပ်ဦး| ဖြိုး| မင်း| သိန်း` ဆိုပြီးဖြစ်နေပါတယ်။
`ဥ`တစ်လုံးဖြုတ်ပြီး၊ `ဦ`နဲ့အစားထိုး ပြင်လိုက်တဲ့အခါမှာတော့ `ဝန်| ကြီး| ချုပ်| ဦး| ဖြိုး| မင်း| သိန်း` ဆိုပြီး အမှန်အတိုင်းရလာပါတယ်။

Cheers!